### PR TITLE
Add SegueManager/R.swift example

### DIFF
--- a/CodeGenExample/Base.lproj/Main.storyboard
+++ b/CodeGenExample/Base.lproj/Main.storyboard
@@ -136,6 +136,7 @@
                                         <segment title="SwiftGen"/>
                                         <segment title="Natalie"/>
                                         <segment title="R.Swift"/>
+                                        <segment title="SegueManager + R.swift"/>
                                         <segment title="CGUtils"/>
                                         <segment title="None"/>
                                     </segments>
@@ -156,11 +157,11 @@
                                 <rect key="frame" x="0.0" y="130" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="WCw-Qf-5nD" id="37f-cq-3Eg">
-                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="Arm-wq-HPj">
-                                            <rect key="frame" x="15" y="0.0" width="290" height="43.5"/>
+                                            <rect key="frame" x="15" y="0.0" width="290" height="43"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <fontDescription key="fontDescription" type="boldSystem" pointSize="20"/>
                                             <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>

--- a/CodeGenExample/DetailViewController.swift
+++ b/CodeGenExample/DetailViewController.swift
@@ -7,10 +7,13 @@
 //
 
 import UIKit
+import SegueManager
 
-class DetailViewController: UIViewController {
+class DetailViewController: UIViewController, SeguePerformer {
 
     @IBOutlet weak var detailDescriptionLabel: UILabel!
+
+    lazy var segueManager: SegueManager = { SegueManager(viewController: self) }()
 
     var generatorType: GeneratorType = .None
 
@@ -67,6 +70,8 @@ class DetailViewController: UIViewController {
             if let segueInfo = R.segue.detailViewController.imageView(segue: segue) {
                 segueInfo.destinationViewController.imageToShow = R.image.lolwut()
             }
+        case .SegueManager_R:
+            segueManager.prepareForSegue(segue)
         case .CodeGenUtils:
             switch segue.identifier {
             case MainStoryboardImageViewIdentifier?:
@@ -89,6 +94,10 @@ class DetailViewController: UIViewController {
             performSegue(Segue.ImageView)
         case .R:
             performSegueWithIdentifier(R.segue.detailViewController.imageView, sender: self)
+        case .SegueManager_R:
+            performSegue(R.segue.detailViewController.imageView) { segue in
+                segue.destinationViewController.imageToShow = R.image.lolwut()
+            }
         case .CodeGenUtils:
             performSegueWithIdentifier(MainStoryboardImageViewIdentifier, sender: self)
         }

--- a/CodeGenExample/MasterViewController.swift
+++ b/CodeGenExample/MasterViewController.swift
@@ -13,6 +13,7 @@ enum GeneratorType: Int {
     case SwiftGen
     case Natalie
     case R
+    case SegueManager_R
     case CodeGenUtils
     case None
 }
@@ -71,6 +72,9 @@ class MasterViewController: UITableViewController {
             if segue == Segue.showDetail {
                 prepareDestinationForDetailSegue(segue.destinationViewController as! UINavigationController)
             }
+        case .SegueManager_R:
+            // A segue triggered from Storyboard is not a case that is supported by SegueManager
+            fallthrough
         case .R:
             if let info = R.segue.masterViewController.showDetail(segue: segue) {
                 prepareDestinationForDetailSegue(info.destinationViewController)

--- a/Podfile
+++ b/Podfile
@@ -2,3 +2,4 @@ platform :ios, '9.0'
 use_frameworks!
 
 pod 'R.swift'
+pod 'SegueManager/R.swift'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,19 @@
 PODS:
-  - R.swift (1.2.0):
-    - R.swift.Library (~> 1.0.1)
-  - R.swift.Library (1.0.1)
+  - R.swift (1.3.0):
+    - R.swift.Library (~> 1.1.0)
+  - R.swift.Library (1.1.0)
+  - SegueManager/iOS (2.0.0)
+  - SegueManager/R.swift (2.0.0):
+    - R.swift.Library
+    - SegueManager/iOS
 
 DEPENDENCIES:
   - R.swift
+  - SegueManager/R.swift
 
 SPEC CHECKSUMS:
-  R.swift: 6cce30887fc8dc3d2185a71c56ed3f1bdbdedf8c
-  R.swift.Library: 801000362d9af80918d16c4de31ddf819e003e03
+  R.swift: 43f8a833dd8cbb4a19908cbfd37fb982e9147899
+  R.swift.Library: 775f3086e07313ed1a1dfddca8418317f5a87397
+  SegueManager: 89523f26f6eff07f4dd1b36b4824303f8d91d2f7
 
 COCOAPODS: 0.39.0


### PR DESCRIPTION
[R.swift](https://github.com/mac-cain13/R.swift) has been designed to work well with my [SegueManager](https://github.com/tomlokhorst/SegueManager) library.

Although your post is titled "Swift Asset Code Generators" (which SegueManager isn't), it also talks about segues.
So I thought I'd show an example of how R.swift and SegueManager work together to allow you to perform a segue with a (typed) closure:

``` swift
performSegue(R.segue.detailViewController.imageView) { segue in
  segue.destinationViewController.imageToShow = R.image.lolwut()
}
```

As mentioned in your post, at the moment R.swift doesn't restrict segues from being performed on the wrong view controller. But this is being worked on: https://github.com/mac-cain13/R.swift.Library/pull/2
